### PR TITLE
added warning to segment talking about permanent changes

### DIFF
--- a/tutorials/plugins/running_code_in_the_editor.rst
+++ b/tutorials/plugins/running_code_in_the_editor.rst
@@ -105,7 +105,7 @@ Here is how a ``_process()`` function might look for you:
         // Code to execute both in editor and in game.
     }
 
-.. note::
+.. warning::
 
     Modifications in the editor are permanent. For example, in the following
     case, when we remove the script, the node will keep its rotation. Be careful


### PR DESCRIPTION
The segment > "Modifications in the editor are permanent. For example, in the following case, when we remove the script, the node will keep its rotation. Be careful to avoid making unwanted modifications."
 Was a note and not a Warning even tho it is one

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
